### PR TITLE
tail_js_extra

### DIFF
--- a/fwtheme_django/templates/fwtheme_django/layout.html
+++ b/fwtheme_django/templates/fwtheme_django/layout.html
@@ -173,5 +173,7 @@
     <script src="http://artefacts.ceda.ac.uk/themes/orgtheme/0.1/_vendor/popper.js/dist/umd/popper.min.js"></script>
     <script src="http://artefacts.ceda.ac.uk/themes/orgtheme/0.1/_vendor/bootstrap/dist/js/bootstrap.min.js"></script>
     <script src="http://artefacts.ceda.ac.uk/themes/orgtheme/0.1/_assets/js/custom.js"></script>
+    
+    {% block tail_js_extra %}{% endblock tail_js_extra %}
   </body>
 </html>


### PR DESCRIPTION
Adds a tail_js_extra block for site-specific javascript which requires jquery.